### PR TITLE
fix(template): fix tag date format

### DIFF
--- a/auto_changelog/templates/base.jinja2
+++ b/auto_changelog/templates/base.jinja2
@@ -12,7 +12,7 @@
 {% endif %}
 
 {% for tag in tags %}
-## {{ tag.name }} ({{ tag.date.strftime('%Y-%M-%d') }})
+## {{ tag.name }} ({{ tag.date.strftime('%Y-%m-%d') }})
 
 {{ macros.commit_list_format(tag) }}
 


### PR DESCRIPTION
This change makes the tag date format use months instead of minutes
