### PR TITLE
feat: Allow optional space between type and scope

### DIFF
--- a/auto_changelog/models.py
+++ b/auto_changelog/models.py
@@ -56,7 +56,7 @@ class Commit:
         self.category, self.specific, self.description = self.categorize()
         
     def categorize(self):
-        match = re.match(r'(\w+)(\(\w+\))?:\s*(.*)', self.first_line)
+        match = re.match(r'(\w+)\ ?(\(\w+\))?:\s*(.*)', self.first_line)
         
         if match:
             category, specific, description = match.groups()


### PR DESCRIPTION
I sometimes accidentally put whitespaces between the commit `type` and the optional `scope`, which will cause the commit to be skipped.

I found it useful to be a bit more forgiving here. Feel free to close the PR if you don't agree.

Thanks for this tool!