### PR TITLE
feat: add --starting-commit and --stopping-commit options

### DIFF
--- a/auto_changelog/__init__.py
+++ b/auto_changelog/__init__.py
@@ -9,8 +9,9 @@ def generate_changelog(
         repository: RepositoryInterface,
         presenter: PresenterInterface,
         title: str = 'Changelog',
-        description: str = ''
+        description: str = '',
+        stopping_commit: str = 'HEAD',
 ) -> Any:
     """ Use-case function coordinates repository and interface """
-    changelog = repository.generate_changelog(title, description)
+    changelog = repository.generate_changelog(title, description, stopping_commit=stopping_commit)
     return presenter.present(changelog)

--- a/auto_changelog/__init__.py
+++ b/auto_changelog/__init__.py
@@ -10,8 +10,9 @@ def generate_changelog(
         presenter: PresenterInterface,
         title: str = 'Changelog',
         description: str = '',
+        starting_commit: str = '',
         stopping_commit: str = 'HEAD',
 ) -> Any:
     """ Use-case function coordinates repository and interface """
-    changelog = repository.generate_changelog(title, description, stopping_commit=stopping_commit)
+    changelog = repository.generate_changelog(title, description, starting_commit=starting_commit, stopping_commit=stopping_commit)
     return presenter.present(changelog)

--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -9,17 +9,17 @@ from auto_changelog.repository import GitRepository
 
 @click.command()
 @click.option('-r', '--repo', type=click.Path(exists=True), default='.')
+@click.option('-t', '--title', default='Changelog')
 @click.option('-o', '--output', type=click.File('w'), default='CHANGELOG.md')
 @click.option('-u', '--unreleased', is_flag=True, default=False)
 @click.option('--stdout', is_flag=True)
 @click.option('--stopping-commit', help='Stopping commit to use for changelog generation', default='HEAD')
-def main(repo, output, unreleased: bool, stdout: bool, stopping_commit: str):
+def main(repo, title, output, unreleased: bool, stdout: bool, stopping_commit: str):
     # Convert the repository name to an absolute path
     repo = os.path.abspath(repo)
 
     repository = GitRepository(repo, skip_unreleased=not unreleased)
     presenter = MarkdownPresenter()
-    title = 'Changelog'
     description = ''
     changelog = generate_changelog(repository, presenter, title, description, stopping_commit=stopping_commit)
     output.write(changelog)

--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -8,13 +8,14 @@ from auto_changelog.repository import GitRepository
 
 
 @click.command()
+@click.option('-r', '--repo', type=click.Path(exists=True), default='.')
 @click.option('-o', '--output', type=click.File('w'), default='CHANGELOG.md')
 @click.option('-u', '--unreleased', is_flag=True, default=False)
 @click.option('--stdout', is_flag=True)
 @click.option('--stopping-commit', help='Stopping commit to use for changelog generation', default='HEAD')
-def main(output, unreleased: bool, stdout: bool, stopping_commit: str):
+def main(repo, output, unreleased: bool, stdout: bool, stopping_commit: str):
     # Convert the repository name to an absolute path
-    repo = os.path.abspath('.')
+    repo = os.path.abspath(repo)
 
     repository = GitRepository(repo, skip_unreleased=not unreleased)
     presenter = MarkdownPresenter()

--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -11,7 +11,8 @@ from auto_changelog.repository import GitRepository
 @click.option('-o', '--output', type=click.File('w'), default='CHANGELOG.md')
 @click.option('-u', '--unreleased', is_flag=True, default=False)
 @click.option('--stdout', is_flag=True)
-def main(output, unreleased: bool, stdout: bool):
+@click.option('--stopping-commit', help='Stopping commit to use for changelog generation', default='HEAD')
+def main(output, unreleased: bool, stdout: bool, stopping_commit: str):
     # Convert the repository name to an absolute path
     repo = os.path.abspath('.')
 
@@ -19,7 +20,7 @@ def main(output, unreleased: bool, stdout: bool):
     presenter = MarkdownPresenter()
     title = 'Changelog'
     description = ''
-    changelog = generate_changelog(repository, presenter, title, description)
+    changelog = generate_changelog(repository, presenter, title, description, stopping_commit=stopping_commit)
     output.write(changelog)
     if stdout:
         print(changelog)

--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -8,19 +8,19 @@ from auto_changelog.repository import GitRepository
 
 
 @click.command()
-@click.option('-r', '--repo', type=click.Path(exists=True), default='.')
-@click.option('-t', '--title', default='Changelog')
-@click.option('-o', '--output', type=click.File('w'), default='CHANGELOG.md')
-@click.option('-u', '--unreleased', is_flag=True, default=False)
+@click.option('-r', '--repo', type=click.Path(exists=True), default='.', help="Path to the repository's root directory [Default: .]")
+@click.option('-t', '--title', default='Changelog', help="The changelog's title [Default: Changelog]")
+@click.option('-d', '--description', help="Your project's description")
+@click.option('-o', '--output', type=click.File('w'), default='CHANGELOG.md', help="The place to save the generated changelog [Default: CHANGELOG.md]")
+@click.option('-u', '--unreleased', is_flag=True, default=False, help="Include section for unreleased changes")
 @click.option('--stdout', is_flag=True)
 @click.option('--stopping-commit', help='Stopping commit to use for changelog generation', default='HEAD')
-def main(repo, title, output, unreleased: bool, stdout: bool, stopping_commit: str):
+def main(repo, title, description, output, unreleased: bool, stdout: bool, stopping_commit: str):
     # Convert the repository name to an absolute path
     repo = os.path.abspath(repo)
 
     repository = GitRepository(repo, skip_unreleased=not unreleased)
     presenter = MarkdownPresenter()
-    description = ''
     changelog = generate_changelog(repository, presenter, title, description, stopping_commit=stopping_commit)
     output.write(changelog)
     if stdout:

--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -14,14 +14,15 @@ from auto_changelog.repository import GitRepository
 @click.option('-o', '--output', type=click.File('w'), default='CHANGELOG.md', help="The place to save the generated changelog [Default: CHANGELOG.md]")
 @click.option('-u', '--unreleased', is_flag=True, default=False, help="Include section for unreleased changes")
 @click.option('--stdout', is_flag=True)
+@click.option('--starting-commit', help='Starting commit to use for changelog generation', default='')
 @click.option('--stopping-commit', help='Stopping commit to use for changelog generation', default='HEAD')
-def main(repo, title, description, output, unreleased: bool, stdout: bool, stopping_commit: str):
+def main(repo, title, description, output, unreleased: bool, stdout: bool, starting_commit: str, stopping_commit: str):
     # Convert the repository name to an absolute path
     repo = os.path.abspath(repo)
 
     repository = GitRepository(repo, skip_unreleased=not unreleased)
     presenter = MarkdownPresenter()
-    changelog = generate_changelog(repository, presenter, title, description, stopping_commit=stopping_commit)
+    changelog = generate_changelog(repository, presenter, title, description, starting_commit=starting_commit, stopping_commit=stopping_commit)
     output.write(changelog)
     if stdout:
         print(changelog)

--- a/auto_changelog/domain_model.py
+++ b/auto_changelog/domain_model.py
@@ -106,7 +106,7 @@ class Changelog:
 
 class RepositoryInterface(ABC):
     @abstractmethod
-    def generate_changelog(self, title: str, description: str, stopping_commit: str) -> Changelog:
+    def generate_changelog(self, title: str, description: str, starting_commit: str, stopping_commit: str) -> Changelog:
         raise NotImplementedError
 
 

--- a/auto_changelog/domain_model.py
+++ b/auto_changelog/domain_model.py
@@ -106,7 +106,7 @@ class Changelog:
 
 class RepositoryInterface(ABC):
     @abstractmethod
-    def generate_changelog(self, title: str, description: str) -> Changelog:
+    def generate_changelog(self, title: str, description: str, stopping_commit: str) -> Changelog:
         raise NotImplementedError
 
 

--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -14,9 +14,9 @@ class GitRepository(RepositoryInterface):
         self.commit_tags_index = self._init_commit_tags_index(self.repository)
         self._skip_unreleased = skip_unreleased
 
-    def generate_changelog(self, title: str = 'Changelog', description: str = '') -> Changelog:
+    def generate_changelog(self, title: str = 'Changelog', description: str = '', stopping_commit: str = 'HEAD') -> Changelog:
         changelog = Changelog(title, description)
-        commits = self.repository.iter_commits('master')  # TODO don't forget to finish revision options
+        commits = self.repository.iter_commits(stopping_commit)
         # Some thoughts here
         #  First we need to check if all commits are "released". If not, we have to create our special "Unreleased"
         #  release. Then we simply iter over all commits, assign them to current release or create new if we find it.

--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -14,9 +14,10 @@ class GitRepository(RepositoryInterface):
         self.commit_tags_index = self._init_commit_tags_index(self.repository)
         self._skip_unreleased = skip_unreleased
 
-    def generate_changelog(self, title: str = 'Changelog', description: str = '', stopping_commit: str = 'HEAD') -> Changelog:
+    def generate_changelog(self, title: str = 'Changelog', description: str = '', starting_commit: str = '', stopping_commit: str = 'HEAD') -> Changelog:
         changelog = Changelog(title, description)
-        commits = self.repository.iter_commits(stopping_commit)
+        iter_rev = self._get_iter_rev(starting_commit, stopping_commit)
+        commits = self.repository.iter_commits(iter_rev)
         # Some thoughts here
         #  First we need to check if all commits are "released". If not, we have to create our special "Unreleased"
         #  release. Then we simply iter over all commits, assign them to current release or create new if we find it.
@@ -39,6 +40,23 @@ class GitRepository(RepositoryInterface):
             attributes = self._extract_note_args(commit)
             changelog.add_note(*attributes)
         return changelog
+
+    def _get_iter_rev(self, starting_commit: str, stopping_commit: str):
+        if starting_commit:
+            c = self.repository.commit(starting_commit)
+            if not c.parents:
+                # starting_commit is initial commit,
+                # treat as default
+                starting_commit = ''
+            else:
+                # iter_commits iters from the first rev to the second rev,
+                # but not contains the second rev.
+                # Here we set the second rev to its previous one then the
+                # second rev would be included.
+                starting_commit = '{}~1'.format(starting_commit)
+
+        iter_rev = '{0}...{1}'.format(stopping_commit, starting_commit) if starting_commit else stopping_commit
+        return iter_rev
 
     @staticmethod
     def _init_commit_tags_index(repo: Repo) -> Dict[Commit, List[TagReference]]:


### PR DESCRIPTION
Work on #28 

```bash
    --latest-rev=LATEST_REV The latest git revision for generating changelog
                            [Default: HEAD]
```

- use `latest_rev` to replace the original `master`
- use `HEAD` as the default value of `latest_rev`

