### PR TITLE
fix: fix latest_version

### DIFF
--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -21,7 +21,7 @@ def main(repo, title, description, output, latest_version: str, unreleased: bool
     # Convert the repository name to an absolute path
     repo = os.path.abspath(repo)
 
-    repository = GitRepository(repo, skip_unreleased=not unreleased)
+    repository = GitRepository(repo, latest_version=latest_version, skip_unreleased=not unreleased)
     presenter = MarkdownPresenter()
     changelog = generate_changelog(repository, presenter, title, description, starting_commit=starting_commit, stopping_commit=stopping_commit)
     output.write(changelog)


### PR DESCRIPTION
The `--latest-version` option does not work as expected because the parsed value was not referenced at all. I've added the reference to the right place and test it.

```bash
-v, --latest-version TEXT  use specified version as latest releas
```