### PR TITLE
fix: disable file writing when stdout specified

### DIFF
--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -24,9 +24,11 @@ def main(repo, title, description, output, latest_version: str, unreleased: bool
     repository = GitRepository(repo, skip_unreleased=not unreleased)
     presenter = MarkdownPresenter()
     changelog = generate_changelog(repository, presenter, title, description, starting_commit=starting_commit, stopping_commit=stopping_commit)
-    output.write(changelog)
+
     if stdout:
         print(changelog)
+    else:
+        output.write(changelog)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `CHANGELOG.md` was modified when I specified `--stdout` option, which is different with it's previous version. So I think it's better no to write the file when `--stdout` was specified.
