### PR TITLE
fix: fix generation of issue url

### DIFF
--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -63,7 +63,7 @@ class GitRepository(RepositoryInterface):
         url = self._get_git_url(remote=remote)
         # 'git@github.com:Michael-F-Bryan/auto-changelog.git' -> 'https://github.com/Michael-F-Bryan/auto-changelog'
         # 'https://github.com/Michael-F-Bryan/auto-changelog.git' -> 'https://github.com/Michael-F-Bryan/auto-changelog'
-        url = re.sub(r"^(https|git)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$", r"https://\3/\4/\5", url)
+        url = re.sub(r"^(https|git|ssh)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$", r"https://\3/\4/\5", url)
         return url
 
     # This part is hard to mock, separate method is nice approach how to overcome this problem

--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -56,13 +56,14 @@ class GitRepository(RepositoryInterface):
 
     def _issue_from_git_remote_url(self, remote: str):
         url = self._remote_url(remote)
-        return urljoin(url, "issues")
+        return urljoin(url + '/', "issues")
 
     def _remote_url(self, remote: str) -> str:
         """ Extract remote url from remote url """
         url = self._get_git_url(remote=remote)
         # 'git@github.com:Michael-F-Bryan/auto-changelog.git' -> 'https://github.com/Michael-F-Bryan/auto-changelog'
-        url = re.sub(r"(git@|ssh@|https?://)(.*):(.*)\..*", r"https://\2/\3", url)
+        # 'https://github.com/Michael-F-Bryan/auto-changelog.git' -> 'https://github.com/Michael-F-Bryan/auto-changelog'
+        url = re.sub(r"^(https|git)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$", r"https://\3/\4/\5", url)
         return url
 
     # This part is hard to mock, separate method is nice approach how to overcome this problem

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -61,8 +61,26 @@ def test_parse_conventional_commit_with_empty_message(message, expected):
 
 
 @patch("auto_changelog.repository.Repo", autospec=True)
-@patch.object(GitRepository, "_get_git_url", return_value="git@github.com:Michael-F-Bryan/auto-changelog.git")
+@patch.object(GitRepository, "_get_git_url")
 def test_get_remote_url(mock_ggu, mock_repo):
+    mock_ggu.return_value = "git@github.com:Michael-F-Bryan/auto-changelog.git"
     remote_url = GitRepository(".")._remote_url(remote="origin")
     expected = "https://github.com/Michael-F-Bryan/auto-changelog"
     assert expected == remote_url
+    mock_ggu.return_value = "https://github.com/Michael-F-Bryan/auto-changelog.git"
+    remote_url = GitRepository(".")._remote_url(remote="origin")
+    expected = "https://github.com/Michael-F-Bryan/auto-changelog"
+    assert expected == remote_url
+
+
+@patch("auto_changelog.repository.Repo", autospec=True)
+@patch.object(GitRepository, "_remote_url", return_value='https://github.com/Michael-F-Bryan/auto-changelog')
+def test_issue_from_git_remote_url(mock_ru, mock_repo):
+    remote_url = GitRepository(".")._issue_from_git_remote_url(remote="origin")
+    expected = "https://github.com/Michael-F-Bryan/auto-changelog/issues"
+    assert expected == remote_url
+
+
+
+
+


### PR DESCRIPTION
Hello ! 

I did some tests and I found a problem in the generation of issue url.
I took the remote url of this repo for https and ssh configuration:
- **https** - `https://github.com/Michael-F-Bryan/auto-changelog.git`
- **ssh** - `git@github.com:Michael-F-Bryan/auto-changelog.git`

The previous regex expression was not handling well the https configuration.

Moreover, the function `_issue_from_git_remote_url` was not doing its job.
We need to add a `/` at the end of the remote url otherwise the result is:
- `https://github.com/Michael-F-Bryan/issues`
- It should be `https://github.com/Michael-F-Bryan/auto-changelog/issues`

I added tests to confirm that the changes are fixing the problems.

Thanks !