### PR TITLE
feat: Add --tag-pattern option #19 (credit to @LeMimit)

### DIFF
--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 import click
 
@@ -34,6 +35,7 @@ from auto_changelog.repository import GitRepository
     help="Override regex pattern for issues in commit messages. Should contain two groups, original match and ID used by issue-url.",
 )
 @click.option("--stdout", is_flag=True)
+@click.option("--tag-pattern", default=None, help="Override regex pattern for release tags")
 @click.option("--starting-commit", help="Starting commit to use for changelog generation", default="")
 @click.option("--stopping-commit", help="Stopping commit to use for changelog generation", default="HEAD")
 def main(
@@ -47,13 +49,16 @@ def main(
     issue_url,
     issue_pattern,
     stdout: bool,
+    tag_pattern: Optional[str],
     starting_commit: str,
     stopping_commit: str,
 ):
     # Convert the repository name to an absolute path
     repo = os.path.abspath(repo)
 
-    repository = GitRepository(repo, latest_version=latest_version, skip_unreleased=not unreleased)
+    repository = GitRepository(
+        repo, latest_version=latest_version, skip_unreleased=not unreleased, tag_pattern=tag_pattern
+    )
     presenter = MarkdownPresenter()
     changelog = generate_changelog(
         repository,

--- a/auto_changelog/domain_model.py
+++ b/auto_changelog/domain_model.py
@@ -3,6 +3,9 @@ from enum import Enum
 from typing import Callable, Union, List, Optional, Tuple, Any
 
 default_issue_pattern = r"(#([\w-]+))"
+# Default aim for Semver tags.
+# Original Semver source: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+default_tag_pattern = "(?P<version>((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*))(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"
 
 
 class ChangeType(Enum):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -36,12 +36,18 @@ def test_latest_version(mock_ggu, mock_ena, mock_era, mock_repo):
 def test_index_init():
     commit1 = Mock()
     commit2 = Mock()
-    tagref1 = Mock(commit=commit1)
-    tagref2 = Mock(commit=commit2)
-    tagref3 = Mock(commit=commit2)
+    tagref1 = Mock()
+    tagref1.commit = commit1
+    tagref1.name = "a"
+    tagref2 = Mock()
+    tagref2.commit = commit2
+    tagref2.name = "b"
+    tagref3 = Mock()
+    tagref3.commit = commit2
+    tagref3.name = "c"
     repo_mock = Mock(spec=Repo, tags=[tagref1, tagref2, tagref3])
 
-    index = GitRepository._init_commit_tags_index(repo_mock)
+    index = GitRepository._init_commit_tags_index(repo_mock, r".*")
     assert index == {commit1: [tagref1], commit2: [tagref2, tagref3]}
 
 


### PR DESCRIPTION
Notes for @LeMimit 

-  I will split your original PR by feature, so discussion about one will not block merge/release of others 
- I changed your implementation in a way, that irrelevant tags are filtered out during tag_index initialization in Repository. I like to read your opinion about this approach.