### PR TITLE
feat: handle breaking changes

### DIFF
--- a/auto_changelog/domain_model.py
+++ b/auto_changelog/domain_model.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Callable, Union, List, Optional, Tuple, Any
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 default_issue_pattern = r"(#([\w-]+))"
 
@@ -28,6 +28,7 @@ class Note:
         scope: str = "",
         body: str = "",
         footer: str = "",
+        breaking_change: str = "",
     ):
         self.sha = sha
         self.change_type = ChangeType(change_type) if change_type else change_type  # TODO Hmm..
@@ -35,6 +36,7 @@ class Note:
         self.description = description
         self.body = body
         self.footer = footer
+        self.breaking_change = breaking_change
 
     def __eq__(self, other):
         return (
@@ -43,6 +45,7 @@ class Note:
             and self.description == other.description
             and self.body == other.body
             and self.footer == other.footer
+            and self.breaking_change == other.breaking_change
         )
 
 
@@ -97,6 +100,10 @@ class Release(Note):
     @property
     def tests(self):
         return self._notes_with_type(ChangeType.TEST)
+
+    @property
+    def breaking_changes(self):
+        return self._notes_with(lambda x: x.breaking_change)
 
     @property
     def has_builds(self):

--- a/auto_changelog/templates/default.jinja2
+++ b/auto_changelog/templates/default.jinja2
@@ -12,4 +12,11 @@
 {{- macros.section('Refactorings', release.refactorings) -}}
 {{- macros.section('Docs', release.docs) -}}
 {{- macros.section('Others', release.builds+release.ci+release.chore+release.reverts+release.style_changes+release.tests) -}}
+{%- if release.breaking_changes %}
+#### BREAKING CHANGES
+
+{% for note in release.breaking_changes -%}
+*{% if note.scope %} ({{ note.scope }}):{% endif %} {{ note.breaking_change }}
+{% endfor -%}
+{% endif -%}
 {% endfor -%}

--- a/tests/test_domain_model.py
+++ b/tests/test_domain_model.py
@@ -1,6 +1,6 @@
-import pytest
 from datetime import date, timedelta
 
+import pytest
 from auto_changelog.domain_model import Changelog
 
 
@@ -24,15 +24,20 @@ def test_changelog_add_note():
     changelog.add_note(sha="345", change_type="feat", description="")
     # unsupported_type should be ignored
     changelog.add_note(sha="567", change_type="unsupported_type", description="")
+    # breaking change
+    changelog.add_note(sha="789", change_type="feat", description="", breaking_change="deprecated")
 
     releases = changelog.releases
     assert len(releases) == 1
     assert releases[0].title == "Unreleased"
     assert len(releases[0].fixes) == 1
     assert releases[0].fixes[0].sha == "123"
-    assert len(releases[0].features) == 1
+    assert len(releases[0].features) == 2
     assert releases[0].features[0].sha == "345"
-    assert len(releases[0]._notes) == 2
+    assert releases[0].features[1].sha == "789"
+    assert len(releases[0].breaking_changes) == 1
+    assert releases[0].breaking_changes[0].sha == "789"
+    assert len(releases[0]._notes) == 3
 
 
 def test_changelog_sorted_releases():

--- a/tests/test_presenter.py
+++ b/tests/test_presenter.py
@@ -1,7 +1,6 @@
 from datetime import date
 
 import pytest
-
 from auto_changelog.domain_model import Changelog, default_issue_pattern
 from auto_changelog.presenter import MarkdownPresenter
 
@@ -56,6 +55,30 @@ def test_markdown_presenter_changelog_with_fixes(changelog, markdown_presenter):
     description = "{}\n\n".format(changelog.description) if changelog.description else ""
     assert_markdown = (
         "# {title}\n\n{description}## Unreleased (2020-01-01)\n\n#### Fixes\n\n* description\n* (scope): description\n"
+    ).format(title=changelog.title, description=description)
+    markdown = markdown_presenter.present(changelog)
+    assert assert_markdown == markdown
+
+
+def test_markdown_presenter_changelog_with_breaking_changes(changelog, markdown_presenter):
+
+    changelog.add_release("Unreleased", date(2020, 1, 1), None)
+    changelog.add_note("", "feat", "description", breaking_change="breaking_change1")
+    changelog.add_note("", "feat", "description", scope="scope", breaking_change="breaking_change2")
+    description = "{}\n\n".format(changelog.description) if changelog.description else ""
+    assert_markdown = (
+        """# {title}\n\n{description}## Unreleased (2020-01-01)
+
+#### New Features
+
+* description
+* (scope): description
+
+#### BREAKING CHANGES
+
+* breaking_change1
+* (scope): breaking_change2
+"""
     ).format(title=changelog.title, description=description)
     markdown = markdown_presenter.present(changelog)
     assert assert_markdown == markdown

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,10 +1,8 @@
+from unittest.mock import Mock, patch
+
 import pytest
-from unittest.mock import Mock
-from unittest.mock import patch
-
-from git import Repo, Commit
-
 from auto_changelog.repository import GitRepository
+from git import Commit, Repo
 
 
 @patch("auto_changelog.repository.Repo", autospec=True)
@@ -48,12 +46,18 @@ def test_index_init():
 @pytest.mark.parametrize(
     "message, expected",
     [
-        ("", ("", "", "", "", "")),
-        ("feat: description", ("feat", "", "description", "", "")),
-        ("feat(scope): description", ("feat", "scope", "description", "", "")),
-        ("feat: description\n\nbody", ("feat", "", "description", "body", "")),
-        ("feat: description\n\nbody\n\nfooter", ("feat", "", "description", "body", "footer")),
-        ("feat(scope): description\n\nbody\n\nfooter", ("feat", "scope", "description", "body", "footer")),
+        ("", ("", "", "", "", "", "")),
+        ("feat: description", ("feat", "", "description", "", "", "")),
+        ("feat(scope): description", ("feat", "scope", "description", "", "", "")),
+        ("feat: description\n\nbody", ("feat", "", "description", "body", "", "")),
+        ("feat: description\n\nbody\n\nfooter", ("feat", "", "description", "body", "footer", "")),
+        ("feat(scope): description\n\nbody\n\nfooter", ("feat", "scope", "description", "body", "footer", "")),
+        ("feat!: description", ("feat", "", "description", "", "", "description")),
+        ("feat(scope)!: description", ("feat", "scope", "description", "", "", "description")),
+        (
+            "feat(scope): description\n\nBREAKING CHANGE: breaking_change",
+            ("feat", "scope", "description", "", "", "breaking_change"),
+        ),
     ],
 )
 def test_parse_conventional_commit_with_empty_message(message, expected):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -50,17 +50,32 @@ def test_index_init():
         ("feat: description", ("feat", "", "description", "", "", "")),
         ("feat(scope): description", ("feat", "scope", "description", "", "", "")),
         ("feat: description\n\nbody", ("feat", "", "description", "body", "", "")),
-        ("feat: description\n\nbody\n\nfooter", ("feat", "", "description", "body", "footer", "")),
-        ("feat(scope): description\n\nbody\n\nfooter", ("feat", "scope", "description", "body", "footer", "")),
+        ("feat: description\n\nmulti-line\n\nbody", ("feat", "", "description", "multi-line\n\nbody", "", "")),
+        (
+            "feat(scope): description\n\nmulti-line\n\nbody",
+            ("feat", "scope", "description", "multi-line\n\nbody", "", ""),
+        ),
+        (
+            "feat: description\n\nmulti-line\n\nbody\n\nReviewed-by: Z",
+            ("feat", "", "description", "multi-line\n\nbody", "Reviewed-by: Z", ""),
+        ),
+        (
+            "feat: description\n\nmulti-line\n\nbody\n\nRefs #133",
+            ("feat", "", "description", "multi-line\n\nbody", "Refs #133", ""),
+        ),
         ("feat!: description", ("feat", "", "description", "", "", "description")),
         ("feat(scope)!: description", ("feat", "scope", "description", "", "", "description")),
         (
             "feat(scope): description\n\nBREAKING CHANGE: breaking_change",
             ("feat", "scope", "description", "", "", "breaking_change"),
         ),
+        (
+            "feat(scope): description\n\nBREAKING-CHANGE: breaking_change",
+            ("feat", "scope", "description", "", "", "breaking_change"),
+        ),
     ],
 )
-def test_parse_conventional_commit_with_empty_message(message, expected):
+def test_parse_conventional_commit(message, expected):
     assert expected == GitRepository._parse_conventional_commit(message)
 
 


### PR DESCRIPTION
Hello,

I add the support for breaking change commit, according to Conventional Commits.

### Exemple:
With theses commit messages :
```
feat!: description1
----------------------------------------------------------------------
feat(scope): description2

BREAKING CHANGE: breaking_change_details
```

generated markdown :
```
# Title

Description

## Unreleased (2020-01-01)

#### New Features

* description1
* (scope): description2

#### BREAKING CHANGES

* description1
* (scope): breaking_change_details
```

Tests :heavy_check_mark: 
Formatting using Black :heavy_check_mark:  