### PR TITLE
feat: add --tag-prefix, --tag-pattern and --compare-url options (rebased)

### DIFF
--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -28,12 +28,22 @@ from auto_changelog.repository import GitRepository
 @click.option("-r", "--remote", default="origin", help="Specify git remote to use for links")
 @click.option("-v", "--latest-version", type=str, help="use specified version as latest release")
 @click.option("-u", "--unreleased", is_flag=True, default=False, help="Include section for unreleased changes")
+@click.option("--compare-url", default=None, help="override url for compares, use {current} and {previous} for tags")
 @click.option("--issue-url", default=None, help="Override url for issues, use {id} for issue id")
 @click.option(
     "--issue-pattern",
     default=r"(#([\w-]+))",
-    help="Override regex pattern for issues in commit messages. Should contain two groups, original match and ID used by issue-url.",
+    help="Override regex pattern for issues in commit messages. Should contain two groups, original match and ID used "
+    "by issue-url.",
 )
+@click.option(
+    "--tag-pattern",
+    default=None,
+    help="override regex pattern for release tags. "
+    "By default use semver tag names semantic. "
+    "tag should be contain in one group named 'version'.",
+)
+@click.option("--tag-prefix", default="", help='prefix used in version tags, default: "" ')
 @click.option("--stdout", is_flag=True)
 @click.option("--tag-pattern", default=None, help="Override regex pattern for release tags")
 @click.option("--starting-commit", help="Starting commit to use for changelog generation", default="")
@@ -46,8 +56,10 @@ def main(
     remote,
     latest_version: str,
     unreleased: bool,
+    compare_url,
     issue_url,
     issue_pattern,
+    tag_prefix,
     stdout: bool,
     tag_pattern: Optional[str],
     starting_commit: str,
@@ -57,7 +69,11 @@ def main(
     repo = os.path.abspath(repo)
 
     repository = GitRepository(
-        repo, latest_version=latest_version, skip_unreleased=not unreleased, tag_pattern=tag_pattern
+        repo,
+        latest_version=latest_version,
+        skip_unreleased=not unreleased,
+        tag_prefix=tag_prefix,
+        tag_pattern=tag_pattern,
     )
     presenter = MarkdownPresenter()
     changelog = generate_changelog(
@@ -68,6 +84,7 @@ def main(
         remote=remote,
         issue_pattern=issue_pattern,
         issue_url=issue_url,
+        compare_url=compare_url,
         starting_commit=starting_commit,
         stopping_commit=stopping_commit,
     )

--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -28,7 +28,7 @@ from auto_changelog.repository import GitRepository
 @click.option("-r", "--remote", default="origin", help="Specify git remote to use for links")
 @click.option("-v", "--latest-version", type=str, help="use specified version as latest release")
 @click.option("-u", "--unreleased", is_flag=True, default=False, help="Include section for unreleased changes")
-@click.option("--compare-url", default=None, help="override url for compares, use {current} and {previous} for tags")
+@click.option("--diff-url", default=None, help="override url for compares, use {current} and {previous} for tags")
 @click.option("--issue-url", default=None, help="Override url for issues, use {id} for issue id")
 @click.option(
     "--issue-pattern",
@@ -56,7 +56,7 @@ def main(
     remote,
     latest_version: str,
     unreleased: bool,
-    compare_url,
+    diff_url,
     issue_url,
     issue_pattern,
     tag_prefix,
@@ -84,7 +84,7 @@ def main(
         remote=remote,
         issue_pattern=issue_pattern,
         issue_url=issue_url,
-        compare_url=compare_url,
+        diff_url=diff_url,
         starting_commit=starting_commit,
         stopping_commit=stopping_commit,
     )

--- a/auto_changelog/domain_model.py
+++ b/auto_changelog/domain_model.py
@@ -50,12 +50,15 @@ class Note:
 
 
 class Release(Note):
-    def __init__(self, title, date, sha, change_type="chore", description="", *args, **kwargs):
+    def __init__(self, title, tag, date, sha, change_type="chore", description="", *args, **kwargs):
         super(Release, self).__init__(sha, change_type, description, *args, **kwargs)
         self.title = title
+        self.tag = tag
         self.date = date
         self._notes = []  # type: List[Note]
         self._changes_indicators = {type_: False for type_ in ChangeType}
+        self.compare_url = None
+        self.previous_tag = None
 
     @property
     def builds(self):
@@ -148,6 +151,10 @@ class Release(Note):
     def add_note(self, note: Note):
         self._notes.append(note)
         self._changes_indicators[note.change_type] = True
+
+    def set_compare_url(self, compare_url: str, previous_tag: str):
+        self.previous_tag = previous_tag
+        self.compare_url = compare_url.format(previous=previous_tag, current=self.tag)
 
     def _notes_with(self, predicate: Callable) -> Tuple[Note]:
         return tuple(filter(predicate, self._notes))

--- a/auto_changelog/domain_model.py
+++ b/auto_changelog/domain_model.py
@@ -166,11 +166,17 @@ class Changelog:
         description: str = "",
         issue_pattern: Optional[str] = None,
         issue_url: Optional[str] = None,
+        tag_prefix: str = "",
+        tag_pattern: Optional[str] = None,
+        compare_url: Optional[str] = None,
     ):
         self.title = title
         self.description = description
         self.issue_pattern = issue_pattern or default_issue_pattern
         self.issue_url = issue_url or ""
+        self.tag_prefix = tag_prefix
+        self.tag_pattern = tag_pattern or default_tag_pattern
+        self.compare_url = compare_url or ""
         self._releases = []  # type: List[Release]
         self._current_release = None  # type: Optional[Release]
 
@@ -207,6 +213,7 @@ class RepositoryInterface(ABC):
         remote: str,
         issue_pattern: Optional[str],
         issue_url: Optional[str],
+        compare_url: Optional[str],
         starting_commit: str,
         stopping_commit: str,
     ) -> Changelog:

--- a/auto_changelog/domain_model.py
+++ b/auto_changelog/domain_model.py
@@ -57,7 +57,7 @@ class Release(Note):
         self.date = date
         self._notes = []  # type: List[Note]
         self._changes_indicators = {type_: False for type_ in ChangeType}
-        self.compare_url = None
+        self.diff_url = None
         self.previous_tag = None
 
     @property
@@ -152,9 +152,9 @@ class Release(Note):
         self._notes.append(note)
         self._changes_indicators[note.change_type] = True
 
-    def set_compare_url(self, compare_url: str, previous_tag: str):
+    def set_compare_url(self, diff_url: str, previous_tag: str):
         self.previous_tag = previous_tag
-        self.compare_url = compare_url.format(previous=previous_tag, current=self.tag)
+        self.diff_url = diff_url.format(previous=previous_tag, current=self.tag)
 
     def _notes_with(self, predicate: Callable) -> Tuple[Note]:
         return tuple(filter(predicate, self._notes))
@@ -175,7 +175,6 @@ class Changelog:
         issue_url: Optional[str] = None,
         tag_prefix: str = "",
         tag_pattern: Optional[str] = None,
-        compare_url: Optional[str] = None,
     ):
         self.title = title
         self.description = description
@@ -183,7 +182,6 @@ class Changelog:
         self.issue_url = issue_url or ""
         self.tag_prefix = tag_prefix
         self.tag_pattern = tag_pattern or default_tag_pattern
-        self.compare_url = compare_url or ""
         self._releases = []  # type: List[Release]
         self._current_release = None  # type: Optional[Release]
 
@@ -220,7 +218,7 @@ class RepositoryInterface(ABC):
         remote: str,
         issue_pattern: Optional[str],
         issue_url: Optional[str],
-        compare_url: Optional[str],
+        diff_url: Optional[str],
         starting_commit: str,
         stopping_commit: str,
     ) -> Changelog:

--- a/auto_changelog/presenter.py
+++ b/auto_changelog/presenter.py
@@ -60,8 +60,8 @@ class MarkdownPresenter(PresenterInterface):
             if (index_version + 1) < len(all_versions):
                 # get version to build compare url
                 current_version = all_versions[index_version]["version"]
-                next_version = all_versions[index_version + 1]["version"]
-                compare_url = url.format(previous=current_version, current=next_version)
+                previous_version = all_versions[index_version + 1]["version"]
+                compare_url = url.format(previous=previous_version, current=current_version)
                 index_version += 1
                 return "{format}[{prefix}{version}]({url})".format(
                     format=tag, prefix=prefix, version=version, url=compare_url

--- a/auto_changelog/presenter.py
+++ b/auto_changelog/presenter.py
@@ -59,8 +59,8 @@ class MarkdownPresenter(PresenterInterface):
             # this is not the last versions of the file
             if (index_version + 1) < len(all_versions):
                 # get version to build compare url
-                current_version = all_versions[index_version]["version"]
-                previous_version = all_versions[index_version + 1]["version"]
+                current_version = "%s%s" % (prefix, all_versions[index_version]["version"])
+                previous_version = "%s%s" % (prefix, all_versions[index_version + 1]["version"])
                 compare_url = url.format(previous=previous_version, current=current_version)
                 index_version += 1
                 return "{format}[{prefix}{version}]({url})".format(

--- a/auto_changelog/presenter.py
+++ b/auto_changelog/presenter.py
@@ -24,53 +24,7 @@ class MarkdownPresenter(PresenterInterface):
     def present(self, changelog: Changelog) -> str:
         text = self.template.render(changelog=changelog)
         text = self._link(changelog.issue_url, changelog.issue_pattern, text)
-        text = self._title(changelog.compare_url, changelog.tag_pattern, changelog.tag_prefix, text)
         return text
-
-    @staticmethod
-    def _title(url, pattern, prefix_value: str, text: str) -> str:
-        """ Replaces all occurrences of pattern in text with markdown links based on tag template """
-        if not url or not pattern:
-            return text
-
-        index_version = 0
-        # regex to get the title format of the release
-        format_regex = "(?P<format>((?m)^#{1,6}(?!#)  *))"
-        # regex to get the prefix / nothing with no prefix
-        prefix_regex = "(?P<prefix>%s)" % prefix_value
-        # build the final regex
-        pattern = "(%s%s%s)" % (format_regex, prefix_regex, pattern)
-        r = re.compile(pattern)
-        # get all versions in the file to use them to build compare url
-        all_versions = [m.groupdict() for m in r.finditer(text)]
-
-        # tag_pattern should contain a group named "version"
-        for versions in all_versions:
-            if "version" not in versions:
-                return text
-
-        def replace(match):
-            nonlocal index_version
-
-            tag = match.group(match.re.groupindex["format"])
-            version = match.group(match.re.groupindex["version"])
-            prefix = match.group(match.re.groupindex["prefix"])
-
-            # this is not the last versions of the file
-            if (index_version + 1) < len(all_versions):
-                # get version to build compare url
-                current_version = "%s%s" % (prefix, all_versions[index_version]["version"])
-                previous_version = "%s%s" % (prefix, all_versions[index_version + 1]["version"])
-                compare_url = url.format(previous=previous_version, current=current_version)
-                index_version += 1
-                return "{format}[{prefix}{version}]({url})".format(
-                    format=tag, prefix=prefix, version=version, url=compare_url
-                )
-            # this is the last version of the file => no need to put compare url
-            else:
-                return "{format}{prefix}{version}".format(format=tag, prefix=prefix, version=version)
-
-        return re.sub(pattern, replace, text)
 
     @staticmethod
     def _link(url, pattern, text: str) -> str:

--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -34,15 +34,13 @@ class GitRepository(RepositoryInterface):
         remote: str = "origin",
         issue_pattern: Optional[str] = None,
         issue_url: Optional[str] = None,
-        compare_url: Optional[str] = None,
+        diff_url: Optional[str] = None,
         starting_commit: str = "",
         stopping_commit: str = "HEAD",
     ) -> Changelog:
         issue_url = issue_url or self._issue_from_git_remote_url(remote)
-        compare_url = compare_url or self._compare_from_git_remote_url(remote)
-        changelog = Changelog(
-            title, description, issue_pattern, issue_url, self.tag_prefix, self.tag_pattern, compare_url
-        )
+        diff_url = diff_url or self._diff_from_git_remote_url(remote)
+        changelog = Changelog(title, description, issue_pattern, issue_url, self.tag_prefix, self.tag_pattern)
         if self._repository_is_empty():
             logging.info("Repository is empty.")
             return changelog
@@ -78,7 +76,7 @@ class GitRepository(RepositoryInterface):
         releases = changelog.releases
         # we are using len(changelog.releases) - 1 because there is not compare url for the oldest version
         for release_index in reversed(range(len(changelog.releases) - 1)):
-            releases[release_index].set_compare_url(compare_url, releases[release_index + 1].title)
+            releases[release_index].set_compare_url(diff_url, releases[release_index + 1].title)
 
         return changelog
 
@@ -91,7 +89,7 @@ class GitRepository(RepositoryInterface):
             logging.error("%s. Turning off issue links.", e)
             return None
 
-    def _compare_from_git_remote_url(self, remote: str):
+    def _diff_from_git_remote_url(self, remote: str):
         try:
             url = self._remote_url(remote)
             return urljoin(url + "/", "compare/{previous}...{current}")

--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -25,7 +25,7 @@ class GitRepository(RepositoryInterface):
         self.commit_tags_index = self._init_commit_tags_index(self.repository, self.tag_prefix, self.tag_pattern)
         # in case of defined latest version, unreleased is used as latest release
         self._skip_unreleased = skip_unreleased and not bool(latest_version)
-        self._latest_version = latest_version or "Unreleased"
+        self._latest_version = latest_version or None
 
     def generate_changelog(
         self,
@@ -60,7 +60,11 @@ class GitRepository(RepositoryInterface):
                 skip = False
 
             if first_commit and commit not in self.commit_tags_index:
-                changelog.add_release(self._latest_version, date.today(), sha256())
+                # if no last version specified by the user => consider HEAD
+                if not self._latest_version:
+                    changelog.add_release("Unreleased", "HEAD", date.today(), sha256())
+                else:
+                    changelog.add_release(self._latest_version, self._latest_version, date.today(), sha256())
             first_commit = False
 
             if commit in self.commit_tags_index:
@@ -69,6 +73,13 @@ class GitRepository(RepositoryInterface):
 
             attributes = self._extract_note_args(commit)
             changelog.add_note(*attributes)
+
+        # create the compare url for each release
+        releases = changelog.releases
+        # we are using len(changelog.releases) - 1 because there is not compare url for the oldest version
+        for release_index in reversed(range(len(changelog.releases) - 1)):
+            releases[release_index].set_compare_url(compare_url, releases[release_index + 1].title)
+
         return changelog
 
     def _issue_from_git_remote_url(self, remote: str) -> Optional[str]:
@@ -163,7 +174,7 @@ class GitRepository(RepositoryInterface):
         return reverse_tag_index
 
     @staticmethod
-    def _extract_release_args(commit, tags) -> Tuple[str, Any, Any]:
+    def _extract_release_args(commit, tags) -> Tuple[str, str, Any, Any]:
         """ Extracts arguments for release """
         title = ", ".join(map(lambda tag: "{}".format(tag.name), tags))
         date_ = commit.authored_datetime.date()
@@ -171,7 +182,7 @@ class GitRepository(RepositoryInterface):
 
         # TODO parse message, be carefull about commit message and tags message
 
-        return title, date_, sha
+        return title, title, date_, sha
 
     @staticmethod
     def _extract_note_args(commit) -> Tuple[str, str, str, str, str, str]:

--- a/auto_changelog/templates/default.jinja2
+++ b/auto_changelog/templates/default.jinja2
@@ -12,7 +12,7 @@
 {{- macros.section('Refactorings', release.refactorings) -}}
 {{- macros.section('Docs', release.docs) -}}
 {{- macros.section('Others', release.builds+release.ci+release.chore+release.reverts+release.style_changes+release.tests) -}}
-{% if release.compare_url %}
-Full set of changes: [`{{release.previous_tag}}...{{release.tag}}`]({{release.compare_url}})
+{% if release.diff_url %}
+Full set of changes: [`{{release.previous_tag}}...{{release.tag}}`]({{release.diff_url}})
 {% endif -%}
 {% endfor -%}

--- a/auto_changelog/templates/default.jinja2
+++ b/auto_changelog/templates/default.jinja2
@@ -12,4 +12,7 @@
 {{- macros.section('Refactorings', release.refactorings) -}}
 {{- macros.section('Docs', release.docs) -}}
 {{- macros.section('Others', release.builds+release.ci+release.chore+release.reverts+release.style_changes+release.tests) -}}
+{% if release.compare_url %}
+Full set of changes: [`{{release.previous_tag}}...{{release.tag}}`]({{release.compare_url}})
+{% endif -%}
 {% endfor -%}

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -206,6 +206,56 @@ def test_option_tag_pattern(test_repo, runner, open_changelog):
         [
             "touch file",
             "git add file",
+            "git commit -m 'feat: Add file' -q",
+            "git tag v-something",
+            "echo 'change' > file",
+            "git add file",
+            "git commit -m 'chore: Change' -q",
+            "git tag 1.0.0",
+            "git tag v2.0.0",
+        ]
+    ],
+)
+def test_option_tag_prefix(test_repo, runner, open_changelog):
+    result = runner.invoke(main, ["--tag-prefix", "v"])
+    assert result.exit_code == 0, result.stderr
+    changelog = open_changelog().read()
+    assert "1.0.0" not in changelog
+    assert "v-something" not in changelog
+    assert "v2.0.0" in changelog
+
+
+@pytest.mark.parametrize(
+    "commands",
+    [
+        [
+            "touch file",
+            "git add file",
+            "git commit -m 'feat: Add file' -q",
+            "git tag release-1",
+            "echo 'change' > file",
+            "git add file",
+            "git commit -m 'chore: Change' -q",
+            "git tag 1",
+            "git tag release-1.2.3",
+        ]
+    ],
+)
+def test_tag_prefix_and_pattern_combination(test_repo, runner, open_changelog):
+    result = runner.invoke(main, ["--tag-prefix", "release-", "--tag-pattern", r"\d"])
+    assert result.exit_code == 0, result.stderr
+    changelog = open_changelog().read()
+    assert "release-1" in changelog
+    assert "## 1 " not in changelog
+    assert "release-1.2.3" not in changelog
+
+
+@pytest.mark.parametrize(
+    "commands",
+    [
+        [
+            "touch file",
+            "git add file",
             "git commit -m 'feat: Add file PRO-1' -q",
             "echo 'change' > file",
             "git add file",

--- a/tests/test_domain_model.py
+++ b/tests/test_domain_model.py
@@ -19,7 +19,7 @@ def test_changelog_add_note_without_release():
 
 def test_changelog_add_note():
     changelog = Changelog()
-    changelog.add_release(title="Unreleased", date=date.today(), sha="")
+    changelog.add_release(title="Unreleased", tag="HEAD", date=date.today(), sha="")
     changelog.add_note(sha="123", change_type="fix", description="")
     changelog.add_note(sha="345", change_type="feat", description="")
     # unsupported_type should be ignored
@@ -28,6 +28,7 @@ def test_changelog_add_note():
     releases = changelog.releases
     assert len(releases) == 1
     assert releases[0].title == "Unreleased"
+    assert releases[0].tag == "HEAD"
     assert len(releases[0].fixes) == 1
     assert releases[0].fixes[0].sha == "123"
     assert len(releases[0].features) == 1
@@ -37,10 +38,12 @@ def test_changelog_add_note():
 
 def test_changelog_sorted_releases():
     changelog = Changelog()
-    changelog.add_release(title="1.2.3", date=date.today(), sha="123")
-    changelog.add_release(title="1.1.1", date=date.today() - timedelta(days=1), sha="456")
+    changelog.add_release(title="1.2.3", tag="1.2.3", date=date.today(), sha="123")
+    changelog.add_release(title="1.1.1", tag="1.1.1", date=date.today() - timedelta(days=1), sha="456")
     releases = changelog.releases
 
     assert len(releases) == 2
     assert releases[0].title == "1.2.3"
     assert releases[1].title == "1.1.1"
+    assert releases[0].tag == "1.2.3"
+    assert releases[1].tag == "1.1.1"

--- a/tests/test_presenter.py
+++ b/tests/test_presenter.py
@@ -95,35 +95,35 @@ def test_link_default_url(markdown_presenter):
         (
             "## 0.3.0 \n## 0.1.7",
             "",
-            "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.3.0...0.1.7) \n## 0.1.7",
+            "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0) \n## 0.1.7",
         ),
         (
             "# 0.3.0 \n# 0.1.7",
             "",
-            "# [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.3.0...0.1.7) \n# 0.1.7",
+            "# [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0) \n# 0.1.7",
         ),
         (
             "### 0.3.0 \n### 0.1.7",
             "",
-            "### [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.3.0...0.1.7) \n### 0.1.7",
+            "### [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0) \n### 0.1.7",
         ),
         (
             "## 0.3.0 \n## 0.1.7\n## 0.1.1",
             "",
-            "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.3.0...0.1.7)"
-            " \n## [0.1.7](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.1.1)\n## 0.1.1",
+            "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0)"
+            " \n## [0.1.7](https://github.com/LeMimit/auto-changelog/compare/0.1.1...0.1.7)\n## 0.1.1",
         ),
         ("## 0.3.0 \n## 0.1.7", "v", "## 0.3.0 \n## 0.1.7"),
         (
             "## v0.3.0 \n## v0.1.7",
             "v",
-            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.3.0...0.1.7) \n## v0.1.7",
+            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0) \n## v0.1.7",
         ),
         (
             "## v0.3.0 \n## v0.1.7\n## v0.1.1",
             "v",
-            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.3.0...0.1.7)"
-            " \n## [v0.1.7](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.1.1)\n## v0.1.1",
+            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0)"
+            " \n## [v0.1.7](https://github.com/LeMimit/auto-changelog/compare/0.1.1...0.1.7)\n## v0.1.1",
         ),
     ],
 )
@@ -144,25 +144,25 @@ def test_compare_default_match(compare_url, text, prefix, expected, markdown_pre
             "## 3 \n## 2",
             "(?P<version>[1-9])",
             "",
-            "## [3](https://github.com/LeMimit/auto-changelog/compare/3...2) \n## 2",
+            "## [3](https://github.com/LeMimit/auto-changelog/compare/2...3) \n## 2",
         ),
-        ("# 3 \n# 2", "(?P<version>[1-9])", "", "# [3](https://github.com/LeMimit/auto-changelog/compare/3...2) \n# 2"),
+        ("# 3 \n# 2", "(?P<version>[1-9])", "", "# [3](https://github.com/LeMimit/auto-changelog/compare/2...3) \n# 2"),
         ("## 3 \n## 2", "([1-9])", "", "## 3 \n## 2"),
         ("## 0.3.0 \n## 0.1.7\n## 0.1.1", "(?P<version>[1-9])", "", "## 0.3.0 \n## 0.1.7\n## 0.1.1"),
         (
             "## 3 \n## 2\n## 1",
             "(?P<version>[1-9])",
             "",
-            "## [3](https://github.com/LeMimit/auto-changelog/compare/3...2)"
-            " \n## [2](https://github.com/LeMimit/auto-changelog/compare/2...1)\n## 1",
+            "## [3](https://github.com/LeMimit/auto-changelog/compare/2...3)"
+            " \n## [2](https://github.com/LeMimit/auto-changelog/compare/1...2)\n## 1",
         ),
         ("## 3 \n## 2\n## 1", "([1-9])", "", "## 3 \n## 2\n## 1"),
         (
             "# 3 \n# 2\n# 1",
             "(?P<version>[1-9])",
             "",
-            "# [3](https://github.com/LeMimit/auto-changelog/compare/3...2)"
-            " \n# [2](https://github.com/LeMimit/auto-changelog/compare/2...1)\n# 1",
+            "# [3](https://github.com/LeMimit/auto-changelog/compare/2...3)"
+            " \n# [2](https://github.com/LeMimit/auto-changelog/compare/1...2)\n# 1",
         ),
     ],
 )

--- a/tests/test_presenter.py
+++ b/tests/test_presenter.py
@@ -185,12 +185,12 @@ def test_compare_default_match(compare_url, text, prefix, expected, markdown_pre
         ),
         ("## v3 \n## v2\n## v1", "([1-9])", "v", "## v3 \n## v2\n## v1"),
         (
-                "# v3 \n# v2\n# v1",
-                "(?P<version>[1-9])",
-                "v",
-                "# [v3](https://github.com/LeMimit/auto-changelog/compare/v2...v3)"
-                " \n# [v2](https://github.com/LeMimit/auto-changelog/compare/v1...v2)\n# v1",
-        )
+            "# v3 \n# v2\n# v1",
+            "(?P<version>[1-9])",
+            "v",
+            "# [v3](https://github.com/LeMimit/auto-changelog/compare/v2...v3)"
+            " \n# [v2](https://github.com/LeMimit/auto-changelog/compare/v1...v2)\n# v1",
+        ),
     ],
 )
 def test_compare_custom_match(compare_url, text, tag_pattern, prefix, expected, markdown_presenter):

--- a/tests/test_presenter.py
+++ b/tests/test_presenter.py
@@ -98,6 +98,11 @@ def test_link_default_url(markdown_presenter):
             "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0) \n## 0.1.7",
         ),
         (
+            "## 0.3.0 \n## 1.0.0-alpha",
+            "",
+            "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/1.0.0-alpha...0.3.0) \n## 1.0.0-alpha",
+        ),
+        (
             "# 0.3.0 \n# 0.1.7",
             "",
             "# [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0) \n# 0.1.7",
@@ -113,17 +118,31 @@ def test_link_default_url(markdown_presenter):
             "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0)"
             " \n## [0.1.7](https://github.com/LeMimit/auto-changelog/compare/0.1.1...0.1.7)\n## 0.1.1",
         ),
+        (
+            "## 0.3.0 \n## 1.2.3-SNAPSHOT-123\n## 1.0.0-rc.1+build.1",
+            "",
+            "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/1.2.3-SNAPSHOT-123...0.3.0)"
+            " \n## [1.2.3-SNAPSHOT-123](https://github.com/LeMimit/auto-changelog/compare/1.0.0-rc.1+build.1...1.2.3-SNAPSHOT-123)"
+            "\n## 1.0.0-rc.1+build.1",
+        ),
         ("## 0.3.0 \n## 0.1.7", "v", "## 0.3.0 \n## 0.1.7"),
         (
             "## v0.3.0 \n## v0.1.7",
             "v",
-            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0) \n## v0.1.7",
+            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/v0.1.7...v0.3.0) \n## v0.1.7",
         ),
         (
             "## v0.3.0 \n## v0.1.7\n## v0.1.1",
             "v",
-            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0)"
-            " \n## [v0.1.7](https://github.com/LeMimit/auto-changelog/compare/0.1.1...0.1.7)\n## v0.1.1",
+            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/v0.1.7...v0.3.0)"
+            " \n## [v0.1.7](https://github.com/LeMimit/auto-changelog/compare/v0.1.1...v0.1.7)\n## v0.1.1",
+        ),
+        (
+            "## v0.3.0 \n## v1.2.3-SNAPSHOT-123\n## v1.0.0-rc.1+build.1",
+            "v",
+            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/v1.2.3-SNAPSHOT-123...v0.3.0)"
+            " \n## [v1.2.3-SNAPSHOT-123](https://github.com/LeMimit/auto-changelog/compare/v1.0.0-rc.1+build.1...v1.2.3-SNAPSHOT-123)"
+            "\n## v1.0.0-rc.1+build.1",
         ),
     ],
 )
@@ -164,6 +183,14 @@ def test_compare_default_match(compare_url, text, prefix, expected, markdown_pre
             "# [3](https://github.com/LeMimit/auto-changelog/compare/2...3)"
             " \n# [2](https://github.com/LeMimit/auto-changelog/compare/1...2)\n# 1",
         ),
+        ("## v3 \n## v2\n## v1", "([1-9])", "v", "## v3 \n## v2\n## v1"),
+        (
+                "# v3 \n# v2\n# v1",
+                "(?P<version>[1-9])",
+                "v",
+                "# [v3](https://github.com/LeMimit/auto-changelog/compare/v2...v3)"
+                " \n# [v2](https://github.com/LeMimit/auto-changelog/compare/v1...v2)\n# v1",
+        )
     ],
 )
 def test_compare_custom_match(compare_url, text, tag_pattern, prefix, expected, markdown_presenter):

--- a/tests/test_presenter.py
+++ b/tests/test_presenter.py
@@ -38,7 +38,7 @@ def test_markdown_presenter_empty_changelog(empty_changelog, markdown_presenter)
 
 
 def test_markdown_presenter_changelog_with_features(changelog, markdown_presenter):
-    changelog.add_release("Unreleased", date(2020, 1, 1), None)
+    changelog.add_release("Unreleased", "HEAD", date(2020, 1, 1), None)
     changelog.add_note("", "feat", "description")
     changelog.add_note("", "feat", "description", scope="scope")
     description = "{}\n\n".format(changelog.description) if changelog.description else ""
@@ -50,7 +50,7 @@ def test_markdown_presenter_changelog_with_features(changelog, markdown_presente
 
 
 def test_markdown_presenter_changelog_with_fixes(changelog, markdown_presenter):
-    changelog.add_release("Unreleased", date(2020, 1, 1), None)
+    changelog.add_release("Unreleased", "HEAD", date(2020, 1, 1), None)
     changelog.add_note("", "fix", "description")
     changelog.add_note("", "fix", "description", scope="scope")
     description = "{}\n\n".format(changelog.description) if changelog.description else ""
@@ -85,114 +85,3 @@ def test_link_default_match(text, expected, markdown_presenter):
 def test_link_default_url(markdown_presenter):
     linked_text = markdown_presenter._link("", default_issue_pattern, "Some text about #42")
     assert linked_text == "Some text about #42"
-
-
-@pytest.mark.parametrize("compare_url", ["https://github.com/LeMimit/auto-changelog/compare/{previous}...{current}"])
-@pytest.mark.parametrize(
-    "text, prefix, expected",
-    [
-        ("## 0.3.0", "", "## 0.3.0"),
-        (
-            "## 0.3.0 \n## 0.1.7",
-            "",
-            "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0) \n## 0.1.7",
-        ),
-        (
-            "## 0.3.0 \n## 1.0.0-alpha",
-            "",
-            "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/1.0.0-alpha...0.3.0) \n## 1.0.0-alpha",
-        ),
-        (
-            "# 0.3.0 \n# 0.1.7",
-            "",
-            "# [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0) \n# 0.1.7",
-        ),
-        (
-            "### 0.3.0 \n### 0.1.7",
-            "",
-            "### [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0) \n### 0.1.7",
-        ),
-        (
-            "## 0.3.0 \n## 0.1.7\n## 0.1.1",
-            "",
-            "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/0.1.7...0.3.0)"
-            " \n## [0.1.7](https://github.com/LeMimit/auto-changelog/compare/0.1.1...0.1.7)\n## 0.1.1",
-        ),
-        (
-            "## 0.3.0 \n## 1.2.3-SNAPSHOT-123\n## 1.0.0-rc.1+build.1",
-            "",
-            "## [0.3.0](https://github.com/LeMimit/auto-changelog/compare/1.2.3-SNAPSHOT-123...0.3.0)"
-            " \n## [1.2.3-SNAPSHOT-123](https://github.com/LeMimit/auto-changelog/compare/1.0.0-rc.1+build.1...1.2.3-SNAPSHOT-123)"
-            "\n## 1.0.0-rc.1+build.1",
-        ),
-        ("## 0.3.0 \n## 0.1.7", "v", "## 0.3.0 \n## 0.1.7"),
-        (
-            "## v0.3.0 \n## v0.1.7",
-            "v",
-            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/v0.1.7...v0.3.0) \n## v0.1.7",
-        ),
-        (
-            "## v0.3.0 \n## v0.1.7\n## v0.1.1",
-            "v",
-            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/v0.1.7...v0.3.0)"
-            " \n## [v0.1.7](https://github.com/LeMimit/auto-changelog/compare/v0.1.1...v0.1.7)\n## v0.1.1",
-        ),
-        (
-            "## v0.3.0 \n## v1.2.3-SNAPSHOT-123\n## v1.0.0-rc.1+build.1",
-            "v",
-            "## [v0.3.0](https://github.com/LeMimit/auto-changelog/compare/v1.2.3-SNAPSHOT-123...v0.3.0)"
-            " \n## [v1.2.3-SNAPSHOT-123](https://github.com/LeMimit/auto-changelog/compare/v1.0.0-rc.1+build.1...v1.2.3-SNAPSHOT-123)"
-            "\n## v1.0.0-rc.1+build.1",
-        ),
-    ],
-)
-def test_compare_default_match(compare_url, text, prefix, expected, markdown_presenter):
-    linked_text = markdown_presenter._title(compare_url, default_tag_pattern, prefix, text)
-    assert linked_text == expected
-
-
-@pytest.mark.parametrize("compare_url", ["https://github.com/LeMimit/auto-changelog/compare/{previous}...{current}"])
-@pytest.mark.parametrize(
-    "text, tag_pattern, prefix, expected",
-    [
-        ("## 0.3.0", "(?P<version>[1-9])", "", "## 0.3.0"),
-        ("## 3", "(?P<version>[1-9])", "", "## 3"),
-        ("## 3", "([1-9])", "", "## 3"),
-        ("## 0.3.0 \n## 0.1.7", "(?P<version>[1-9])", "", "## 0.3.0 \n## 0.1.7"),
-        (
-            "## 3 \n## 2",
-            "(?P<version>[1-9])",
-            "",
-            "## [3](https://github.com/LeMimit/auto-changelog/compare/2...3) \n## 2",
-        ),
-        ("# 3 \n# 2", "(?P<version>[1-9])", "", "# [3](https://github.com/LeMimit/auto-changelog/compare/2...3) \n# 2"),
-        ("## 3 \n## 2", "([1-9])", "", "## 3 \n## 2"),
-        ("## 0.3.0 \n## 0.1.7\n## 0.1.1", "(?P<version>[1-9])", "", "## 0.3.0 \n## 0.1.7\n## 0.1.1"),
-        (
-            "## 3 \n## 2\n## 1",
-            "(?P<version>[1-9])",
-            "",
-            "## [3](https://github.com/LeMimit/auto-changelog/compare/2...3)"
-            " \n## [2](https://github.com/LeMimit/auto-changelog/compare/1...2)\n## 1",
-        ),
-        ("## 3 \n## 2\n## 1", "([1-9])", "", "## 3 \n## 2\n## 1"),
-        (
-            "# 3 \n# 2\n# 1",
-            "(?P<version>[1-9])",
-            "",
-            "# [3](https://github.com/LeMimit/auto-changelog/compare/2...3)"
-            " \n# [2](https://github.com/LeMimit/auto-changelog/compare/1...2)\n# 1",
-        ),
-        ("## v3 \n## v2\n## v1", "([1-9])", "v", "## v3 \n## v2\n## v1"),
-        (
-            "# v3 \n# v2\n# v1",
-            "(?P<version>[1-9])",
-            "v",
-            "# [v3](https://github.com/LeMimit/auto-changelog/compare/v2...v3)"
-            " \n# [v2](https://github.com/LeMimit/auto-changelog/compare/v1...v2)\n# v1",
-        ),
-    ],
-)
-def test_compare_custom_match(compare_url, text, tag_pattern, prefix, expected, markdown_presenter):
-    linked_text = markdown_presenter._title(compare_url, tag_pattern, prefix, text)
-    assert linked_text == expected

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -36,19 +36,56 @@ def test_latest_version(mock_ggu, mock_ena, mock_era, mock_repo):
 def test_index_init():
     commit1 = Mock()
     commit2 = Mock()
-    tagref1 = Mock()
-    tagref1.commit = commit1
-    tagref1.name = "a"
-    tagref2 = Mock()
-    tagref2.commit = commit2
-    tagref2.name = "b"
-    tagref3 = Mock()
-    tagref3.commit = commit2
-    tagref3.name = "c"
+    tagref1 = Mock(commit=commit1)
+    tagref1.name = "1.0.0"
+    tagref2 = Mock(commit=commit2)
+    tagref2.name = "2.0.0"
+    tagref3 = Mock(commit=commit2)
+    tagref3.name = "2.0.0"
+
     repo_mock = Mock(spec=Repo, tags=[tagref1, tagref2, tagref3])
 
-    index = GitRepository._init_commit_tags_index(repo_mock, r".*")
+    # no prefix
+    tag_prefix = ""
+    # we are using default tag pattern => semantic versioning
+    tag_pattern = None
+
+    index = GitRepository._init_commit_tags_index(repo_mock, tag_prefix, tag_pattern)
     assert index == {commit1: [tagref1], commit2: [tagref2, tagref3]}
+
+
+@pytest.mark.parametrize("tags", [["1.0.0", "1.0.0-beta", "v2.0.0", "v3.0.0", "4.0", "5", "v6"]])
+@pytest.mark.parametrize(
+    "tag_prefix, tag_pattern, expected_tags",
+    [
+        ("", None, ["1.0.0", "1.0.0-beta"]),
+        ("v", None, ["v2.0.0", "v3.0.0"]),
+        ("x", None, []),
+        ("", "([1-9])", ["5"]),
+        ("v", "([1-9])", ["v6"]),
+        ("x", "([1-9])", []),
+    ],
+)
+def test_tag_pattern(tags, tag_prefix, tag_pattern, expected_tags):
+    tag_refs = []
+    for tag in tags:
+        tag_ref = Mock(commit=Mock())
+        tag_ref.name = tag
+        tag_refs.append(tag_ref)
+
+    repo_mock = Mock(spec=Repo, tags=tag_refs)
+
+    selected_tag_refs = GitRepository._init_commit_tags_index(repo_mock, tag_prefix, tag_pattern)
+
+    selected_tags = []
+    for selected_tag_ref_list in selected_tag_refs.values():
+        for selected_tag_ref in selected_tag_ref_list:
+            selected_tags.append(selected_tag_ref.name)
+
+    if len(selected_tags) == 0:
+        assert len(expected_tags) == 0
+    else:
+        assert all([a == b for a, b in zip(selected_tags, expected_tags)])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -82,10 +82,7 @@ def test_tag_pattern(tags, tag_prefix, tag_pattern, expected_tags):
         for selected_tag_ref in selected_tag_ref_list:
             selected_tags.append(selected_tag_ref.name)
 
-    if len(selected_tags) == 0:
-        assert len(expected_tags) == 0
-    else:
-        assert all([a == b for a, b in zip(selected_tags, expected_tags)])
+    assert selected_tags == expected_tags
 
 
 @pytest.mark.parametrize(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -82,7 +82,7 @@ def test_tag_pattern(tags, tag_prefix, tag_pattern, expected_tags):
         for selected_tag_ref in selected_tag_ref_list:
             selected_tags.append(selected_tag_ref.name)
 
-    assert selected_tags == expected_tags
+    assert sorted(selected_tags) == sorted(expected_tags)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
From original PR by @LeMimit :

> Hello !
> 
> I added the following options :
> 
>     --tag-prefix: prefix used in version tags, default: ""
> 
>     --tag-pattern: override regex pattern for release tags.
>     By default, I using semver tag names (spec).
>     For the pattern, I based my code on the regex provided in the spec (link).
>     The regex provided must contains a group named "version" which represent the version.
>     Exemple: "(?P<version>[1-9])"
> 
>     --compare-url: override url for compares, use {current} and {previous} for tags.
>     The code automatically detects the release title in the changelog based on the tag prefix and tag pattern and insert the compare url.
> 
> I created new tests in order to test this new options !

Yesterday I looked at your(@LeMimit) original PR and our discussion about how these features should work together and the conclusion is: I spend more time moving towards your solution.

Rebased, added integration tests.

Please review and I will merge it.

Closes #67, closes #68, closes #45 and closes #56 