### PR TITLE
docs: Add usage section and command line options to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,46 @@ or directly from source(via poetry):
     poetry build
     pip install dist/*.whl
 
+Usage
+-----
+You can list the command line options by running `auto-changelog --help`:
+
+.. code-block:: text
+
+    Usage: auto-changelog [OPTIONS]
+    
+    Options:
+      -r, --repo PATH            Path to the repository's root directory [Default:
+                                 .]
+    
+      -t, --title TEXT           The changelog's title [Default: Changelog]
+      -d, --description TEXT     Your project's description
+      -o, --output FILENAME      The place to save the generated changelog
+                                 [Default: CHANGELOG.md]
+    
+      -r, --remote TEXT          Specify git remote to use for links
+      -v, --latest-version TEXT  use specified version as latest release
+      -u, --unreleased           Include section for unreleased changes
+      --diff-url TEXT            override url for compares, use {current} and
+                                 {previous} for tags
+    
+      --issue-url TEXT           Override url for issues, use {id} for issue id
+      --issue-pattern TEXT       Override regex pattern for issues in commit
+                                 messages. Should contain two groups, original
+                                 match and ID used by issue-url.
+    
+      --tag-pattern TEXT         override regex pattern for release tags. By
+                                 default use semver tag names semantic. tag should
+                                 be contain in one group named 'version'.
+    
+      --tag-prefix TEXT          prefix used in version tags, default: ""
+      --stdout
+      --tag-pattern TEXT         Override regex pattern for release tags
+      --starting-commit TEXT     Starting commit to use for changelog generation
+      --stopping-commit TEXT     Stopping commit to use for changelog generation
+      --help                     Show this message and exit.
+
+
 A simple example
 ----------------
 


### PR DESCRIPTION
For reference it is nice to list all command line options in the README.
