### PR TITLE
Improve parsing of conventional commits

### DIFF
--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -193,15 +193,19 @@ class GitRepository(RepositoryInterface):
 
     @staticmethod
     def _parse_conventional_commit(message: str) -> Tuple[str, str, str, str, str]:
-        type_ = scope = description = body = footer = ""
+        type_ = scope = description = body_footer = body = footer = ""
         # TODO this is less restrictive version of re. I have somewhere more restrictive one, maybe as option?
-        match = re.match(r"^(\w+)(\(\w+\))?: (.*)(\n\n.+)?(\n\n.+)?$", message)
+        match = re.match(r"^(\w+)(\(\w+\))?: (.*)(\n\n[\w\W]+)?$", message)
         if match:
-            type_, scope, description, body, footer = match.groups(default="")
+            type_, scope, description, body_footer = match.groups(default="")
         if scope:
             scope = scope[1:-1]
-        if body:
-            body = body[2:]
-        if footer:
-            footer = footer[2:]
+        if body_footer:
+            bf_match = re.match(r"^(\n\n[\w\W]+?)?(\n\n[a-zA-Z-]+(: | #)[\w\W]+)$", body_footer)
+            if bf_match:
+                result = bf_match.groups(default="")
+                body = result[0][2:]
+                footer = result[1][2:]
+            else:
+                body = body_footer[2:]
         return type_, scope, description, body, footer

--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -195,13 +195,13 @@ class GitRepository(RepositoryInterface):
     def _parse_conventional_commit(message: str) -> Tuple[str, str, str, str, str]:
         type_ = scope = description = body_footer = body = footer = ""
         # TODO this is less restrictive version of re. I have somewhere more restrictive one, maybe as option?
-        match = re.match(r"^(\w+)(\(\w+\))?: (.*)(\n\n[\w\W]+)?$", message)
+        match = re.match(r"^(\w+)(\(\w+\))?!?: (.*)(\n\n[\w\W]+)?$", message)
         if match:
             type_, scope, description, body_footer = match.groups(default="")
         if scope:
             scope = scope[1:-1]
         if body_footer:
-            bf_match = re.match(r"^(\n\n[\w\W]+?)?(\n\n[a-zA-Z-]+(: | #)[\w\W]+)$", body_footer)
+            bf_match = re.match(r"^(\n\n[\w\W]+?)?(\n\n([a-zA-Z-]+|BREAKING[- ]CHANGE)(: | #)[\w\W]+)$", body_footer)
             if bf_match:
                 result = bf_match.groups(default="")
                 body = result[0][2:]

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -316,3 +316,111 @@ def test_stopping_commit(test_repo, runner, open_changelog):
     changelog = open_changelog().read()
     assert "Add file PRO-1" in changelog
     assert "Some file fix" not in changelog
+
+
+@pytest.mark.parametrize(
+    "commands", [["touch file", "git add file", "git commit -m 'feat: Add file #1\n\nBody line' -q", "git log"]]
+)
+def test_single_line_body(test_repo, runner, open_changelog):
+    result = runner.invoke(main, ["--unreleased"])
+    assert result.exit_code == 0, result.stderr
+    assert result.output == ""
+    changelog = open_changelog().read()
+    print(changelog)
+    assert "Add file #1" in changelog
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "commands",
+    [["touch file", "git add file", "git commit -m 'feat: Add file #1\n\nBody line 1\nBody line 2' -q", "git log"]],
+)
+def test_double_line_body(test_repo, runner, open_changelog):
+    result = runner.invoke(main, ["--unreleased"])
+    assert result.exit_code == 0, result.stderr
+    assert result.output == ""
+    changelog = open_changelog().read()
+    print(changelog)
+    assert "Add file #1" in changelog
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "commands",
+    [
+        [
+            "touch file",
+            "git add file",
+            "git commit -m 'feat: Add file #1\n\nBody line 1\nBody line 2\nBody line 3' -q",
+            "git log",
+        ]
+    ],
+)
+def test_triple_line_body(test_repo, runner, open_changelog):
+    result = runner.invoke(main, ["--unreleased"])
+    assert result.exit_code == 0, result.stderr
+    assert result.output == ""
+    changelog = open_changelog().read()
+    print(changelog)
+    assert "Add file #1" in changelog
+
+
+@pytest.mark.parametrize(
+    "commands",
+    [
+        [
+            "touch file",
+            "git add file",
+            "git commit -m 'feat: Add file #1\n\nBody paragraph 1\n\nBody paragraph 2' -q",
+            "git log",
+        ]
+    ],
+)
+def test_multi_paragraph_body(test_repo, runner, open_changelog):
+    result = runner.invoke(main, ["--unreleased"])
+    assert result.exit_code == 0, result.stderr
+    assert result.output == ""
+    changelog = open_changelog().read()
+    print(changelog)
+    assert "Add file #1" in changelog
+
+
+@pytest.mark.parametrize(
+    "commands",
+    [
+        [
+            "touch file",
+            "git add file",
+            "git commit -m 'feat: Add file #1\n\nBody line\n\nFooter: first footer' -q",
+            "git log",
+        ]
+    ],
+)
+def test_single_line_body_single_footer(test_repo, runner, open_changelog):
+    result = runner.invoke(main, ["--unreleased"])
+    assert result.exit_code == 0, result.stderr
+    assert result.output == ""
+    changelog = open_changelog().read()
+    print(changelog)
+    assert "Add file #1" in changelog
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "commands",
+    [
+        [
+            "touch file",
+            "git add file",
+            "git commit -m 'feat: Add file #1\n\nBody line\n\nFooter: first footer\nFooter: second footer' -q",
+            "git log",
+        ]
+    ],
+)
+def test_single_line_body_double_footer(test_repo, runner, open_changelog):
+    result = runner.invoke(main, ["--unreleased"])
+    assert result.exit_code == 0, result.stderr
+    assert result.output == ""
+    changelog = open_changelog().read()
+    print(changelog)
+    assert "Add file #1" in changelog

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -330,7 +330,6 @@ def test_single_line_body(test_repo, runner, open_changelog):
     assert "Add file #1" in changelog
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "commands",
     [["touch file", "git add file", "git commit -m 'feat: Add file #1\n\nBody line 1\nBody line 2' -q", "git log"]],
@@ -344,7 +343,6 @@ def test_double_line_body(test_repo, runner, open_changelog):
     assert "Add file #1" in changelog
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "commands",
     [
@@ -405,7 +403,6 @@ def test_single_line_body_single_footer(test_repo, runner, open_changelog):
     assert "Add file #1" in changelog
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "commands",
     [

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -92,8 +92,45 @@ def test_tag_pattern(tags, tag_prefix, tag_pattern, expected_tags):
         ("feat: description", ("feat", "", "description", "", "")),
         ("feat(scope): description", ("feat", "scope", "description", "", "")),
         ("feat: description\n\nbody", ("feat", "", "description", "body", "")),
-        ("feat: description\n\nbody\n\nfooter", ("feat", "", "description", "body", "footer")),
-        ("feat(scope): description\n\nbody\n\nfooter", ("feat", "scope", "description", "body", "footer")),
+        ("feat: description\n\nbody\nbody2", ("feat", "", "description", "body\nbody2", "")),
+        ("feat: description\n\nbody\nbody2\nbody3", ("feat", "", "description", "body\nbody2\nbody3", "")),
+        ("feat: description\n\nparagraph1\n\nparagraph2", ("feat", "", "description", "paragraph1\n\nparagraph2", "")),
+        (
+            "feat: description\n\nbody\n\nFooter: footer text",
+            ("feat", "", "description", "body", "Footer: footer text"),
+        ),
+        ("feat: description\n\nbody\n\nCloses #11", ("feat", "", "description", "body", "Closes #11")),
+        (
+            "feat: description\n\nbody\n\nFooter #1\nFooter: second",
+            ("feat", "", "description", "body", "Footer #1\nFooter: second"),
+        ),
+        (
+            "feat: description\n\nbody1\nbody2\n\nbodypara2\n\nFooter #1\nFooter: second but this a rather long footer\nspanning accross two lines\nFooter: third",
+            (
+                "feat",
+                "",
+                "description",
+                "body1\nbody2\n\nbodypara2",
+                "Footer #1\nFooter: second but this a rather long footer\nspanning accross two lines\nFooter: third",
+            ),
+        ),
+        ("feat: description\n\nFooter: footer text", ("feat", "", "description", "", "Footer: footer text"),),
+        ("feat: description\n\nCloses #11", ("feat", "", "description", "", "Closes #11")),
+        (
+            "feat: description\n\nFooter #1\nFooter: second",
+            ("feat", "", "description", "", "Footer #1\nFooter: second"),
+        ),
+        ("feat(scope): description\n\nbody\n\nFooter #1", ("feat", "scope", "description", "body", "Footer #1")),
+        (
+            "fix: correct minor typos in code\n\nsee the issue for details\n\non typos fixed.\n\nReviewed-by: Z\nRefs #133",
+            (
+                "fix",
+                "",
+                "correct minor typos in code",
+                "see the issue for details\n\non typos fixed.",
+                "Reviewed-by: Z\nRefs #133",
+            ),
+        ),
     ],
 )
 def test_parse_conventional_commit_with_empty_message(message, expected):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -131,6 +131,18 @@ def test_tag_pattern(tags, tag_prefix, tag_pattern, expected_tags):
                 "Reviewed-by: Z\nRefs #133",
             ),
         ),
+        ("feat!: description\n\nbody\n\nFooter #1", ("feat", "", "description", "body", "Footer #1")),
+        ("feat(scope)!: description\n\nbody\n\nFooter #1", ("feat", "scope", "description", "body", "Footer #1")),
+        (
+            "feat: description\n\nbody\n\nBREAKING-CHANGE: details",
+            ("feat", "", "description", "body", "BREAKING-CHANGE: details"),
+        ),
+        (
+            "feat: description\n\nbody\n\nBREAKING CHANGE: details",
+            ("feat", "", "description", "body", "BREAKING CHANGE: details"),
+        ),
+        ("feat: description\n\nBREAKING-CHANGE: details", ("feat", "", "description", "", "BREAKING-CHANGE: details")),
+        ("feat: description\n\nBREAKING CHANGE: details", ("feat", "", "description", "", "BREAKING CHANGE: details")),
     ],
 )
 def test_parse_conventional_commit_with_empty_message(message, expected):


### PR DESCRIPTION
This PR addresses several shortcomings of the current commmit parsing algorithm:

auto-changelog  is neglecting the following paragraphs of Conventional Commits 1.0.0 specification
https://www.conventionalcommits.org/en/v1.0.0/ :

> 7. A commit body is free-form and MAY consist of any number of newline separated paragraphs.
- auto-changelog only accepts a single paragraph single line commit body.

> 8. One or more footers MAY be provided one blank line after the body. Each footer MUST consist of
 a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the
  [git trailer convention](https://git-scm.com/docs/git-interpret-trailers)).
> 9. A footer's token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate
  the footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
- auto-changelog only accepts a single footer and does not check against word tokens and the subsequent separator.

> 10. A footer's value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer
  token/separator pair is observed.
- auto-changelog only accepts a single footer 

Additionally, auto-changelog is ignoring commits if the breaking-change indicator (!) is used in the type/scope prefix of a commit

This PR will close #79.