### PR TITLE
Fix sanitation of remote url

### DIFF
--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -101,10 +101,14 @@ class GitRepository(RepositoryInterface):
     def _remote_url(self, remote: str) -> str:
         """ Extract remote url from remote url """
         url = self._get_git_url(remote=remote)
+        url = GitRepository._sanitize_remote_url(url)
+        return url
+
+    @staticmethod
+    def _sanitize_remote_url(remote: str) -> str:
         # 'git@github.com:Michael-F-Bryan/auto-changelog.git' -> 'https://github.com/Michael-F-Bryan/auto-changelog'
         # 'https://github.com/Michael-F-Bryan/auto-changelog.git' -> 'https://github.com/Michael-F-Bryan/auto-changelog'
-        url = re.sub(r"^(https|git|ssh)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$", r"https://\3/\4/\5", url)
-        return url
+        return re.sub(r"^(https|git|ssh)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$", r"https://\3/\4/\5", remote)
 
     # This part is hard to mock, separate method is nice approach how to overcome this problem
     def _get_git_url(self, remote: str) -> str:

--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -108,7 +108,7 @@ class GitRepository(RepositoryInterface):
     def _sanitize_remote_url(remote: str) -> str:
         # 'git@github.com:Michael-F-Bryan/auto-changelog.git' -> 'https://github.com/Michael-F-Bryan/auto-changelog'
         # 'https://github.com/Michael-F-Bryan/auto-changelog.git' -> 'https://github.com/Michael-F-Bryan/auto-changelog'
-        return re.sub(r"^(https|git|ssh)(:\/\/|@)([^\/:]+)[\/:]([^\/:]+)\/(.+).git$", r"https://\3/\4/\5", remote)
+        return re.sub(r"^(https|git|ssh)(:\/\/|@)(.*@)?([^\/:]+)[\/:]([^\/:]+)\/(.+).git$", r"https://\4/\5/\6", remote)
 
     # This part is hard to mock, separate method is nice approach how to overcome this problem
     def _get_git_url(self, remote: str) -> str:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -119,3 +119,16 @@ def test_issue_from_git_remote_url(mock_ru, mock_repo):
     remote_url = GitRepository(".")._issue_from_git_remote_url(remote="origin")
     expected = "https://github.com/Michael-F-Bryan/auto-changelog/issues/{id}"
     assert expected == remote_url
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("git@github.com:Michael-F-Bryan/auto-changelog.git", "https://github.com/Michael-F-Bryan/auto-changelog"),
+        ("https://github.com/Michael-F-Bryan/auto-changelog.git", "https://github.com/Michael-F-Bryan/auto-changelog"),
+        ("git@gitlab.com:Michael-F-Bryan/auto-changelog.git", "https://gitlab.com/Michael-F-Bryan/auto-changelog"),
+        ("https://gitlab.com/Michael-F-Bryan/auto-changelog.git", "https://gitlab.com/Michael-F-Bryan/auto-changelog"),
+    ],
+)
+def test_remote_url(input, expected):
+    assert expected == GitRepository._sanitize_remote_url(input)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -128,6 +128,18 @@ def test_issue_from_git_remote_url(mock_ru, mock_repo):
         ("https://github.com/Michael-F-Bryan/auto-changelog.git", "https://github.com/Michael-F-Bryan/auto-changelog"),
         ("git@gitlab.com:Michael-F-Bryan/auto-changelog.git", "https://gitlab.com/Michael-F-Bryan/auto-changelog"),
         ("https://gitlab.com/Michael-F-Bryan/auto-changelog.git", "https://gitlab.com/Michael-F-Bryan/auto-changelog"),
+        (
+            "https://username:0123456789abcdef0123456789abcdef01234567@github.com/Michael-F-Bryan/auto-changelog.git",
+            "https://github.com/Michael-F-Bryan/auto-changelog",
+        ),
+        (
+            "https://0123456789abcdef0123456789abcdef01234567@github.com/Michael-F-Bryan/auto-changelog.git",
+            "https://github.com/Michael-F-Bryan/auto-changelog",
+        ),
+        (
+            "https://username:0123456789abcdef0123456789abcdef01234567@gitlab.com/Michael-F-Bryan/auto-changelog.git",
+            "https://gitlab.com/Michael-F-Bryan/auto-changelog",
+        ),
     ],
 )
 def test_remote_url(input, expected):


### PR DESCRIPTION
Fix sanitation of remote url to avoid leaking of credentials

- [x] pytest  :white_check_mark:
- [x] black :white_check_mark:

Closes #83 