### PR TITLE
fix(regex): accept empty additional commit body

### DIFF
--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -213,7 +213,7 @@ class GitRepository(RepositoryInterface):
     def _parse_conventional_commit(message: str) -> Tuple[str, str, str, str, str]:
         type_ = scope = description = body_footer = body = footer = ""
         # TODO this is less restrictive version of re. I have somewhere more restrictive one, maybe as option?
-        match = re.match(r"^(\w+)(\(\w+\))?!?: (.*)(\n\n[\w\W]+)?$", message)
+        match = re.match(r"^(\w+)(\(\w+\))?!?: (.*)(\n\n[\w\W]*)?$", message)
         if match:
             type_, scope, description, body_footer = match.groups(default="")
         else:

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -453,11 +453,24 @@ def test_single_line_body(runner, open_changelog):
         [
             "echo test > file",
             "git add file",
-            'git commit -m "feat: Add file #1\n\nBody line 1\nBody line 2" -q',
+            'git commit -m "feat: Add file #1\n\n" -q',
             "git log",
             "git remote add origin https://github.com/Michael-F-Bryan/auto-changelog.git",
         ]
     ],
+)
+def test_empty_line_body(test_repo, runner, open_changelog):
+    result = runner.invoke(main, ["--unreleased"])
+    assert result.exit_code == 0, result.stderr
+    assert result.output == ""
+    changelog = open_changelog().read()
+    print(changelog)
+    assert "Add file [#1]" in changelog
+
+
+@pytest.mark.parametrize(
+    "commands",
+    [["touch file", "git add file", "git commit -m 'feat: Add file #1\n\nBody line 1\nBody line 2' -q", "git log"]],
 )
 def test_double_line_body(runner, open_changelog):
     result = runner.invoke(main, ["--unreleased"])

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -94,6 +94,7 @@ def test_tag_pattern(tags, tag_prefix, tag_pattern, expected_tags):
         ("feat(scope): description", ("feat", "scope", "description", "", "")),
         ("feat: description\n\nbody", ("feat", "", "description", "body", "")),
         ("feat: description\n\nbody\nbody2", ("feat", "", "description", "body\nbody2", "")),
+        ("feat: description\n\n", ("feat", "", "description", "", "")),
         ("feat: description\n\nbody\nbody2\nbody3", ("feat", "", "description", "body\nbody2\nbody3", "")),
         ("feat: description\n\nparagraph1\n\nparagraph2", ("feat", "", "description", "paragraph1\n\nparagraph2", "")),
         (


### PR DESCRIPTION
Change regex to support empty additional commit body.
Support default behaviour of github squash merging.

- [x] pytest :heavy_check_mark:
- [x] black :heavy_check_mark:

Closes #85 