### PR TITLE
fix(git): clean references after process

### DIFF
--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -89,6 +89,10 @@ class GitRepository(RepositoryInterface):
             for release_index in reversed(range(len(changelog.releases) - 1)):
                 releases[release_index].set_compare_url(diff_url, releases[release_index + 1].title)
 
+        # Close the link to the repository
+        # If we are not closing it, some references are not cleaned on windows
+        self.repository.close()
+
         return changelog
 
     def _issue_from_git_remote_url(self, remote: str) -> Optional[str]:


### PR DESCRIPTION
Use the `close` function of `gitPython` to clean the references after the process.

- [x] black :heavy_check_mark:

Closes #87 