### PR TITLE
build: Add flake8 as linter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/auto_changelog/domain_model.py
+++ b/auto_changelog/domain_model.py
@@ -6,7 +6,7 @@ from typing import Callable, Union, List, Optional, Tuple, Any
 default_issue_pattern = r"(#([\w-]+))"
 # Default aim for Semver tags.
 # Original Semver source: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-default_tag_pattern = "(?P<version>((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*))(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"
+default_tag_pattern = r"(?P<version>((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*))(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"
 
 
 class ChangeType(Enum):

--- a/auto_changelog/domain_model.py
+++ b/auto_changelog/domain_model.py
@@ -6,7 +6,7 @@ from typing import Callable, Union, List, Optional, Tuple, Any
 default_issue_pattern = r"(#([\w-]+))"
 # Default aim for Semver tags.
 # Original Semver source: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-default_tag_pattern = r"(?P<version>((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*))(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"
+default_tag_pattern = r"(?P<version>((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*))(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"  # noqa: E501
 
 
 class ChangeType(Enum):

--- a/poetry.lock
+++ b/poetry.lock
@@ -91,6 +91,23 @@ python-versions = "*"
 version = "0.6.2"
 
 [[package]]
+category = "dev"
+description = "the modular source code checker: pep8 pyflakes and co"
+name = "flake8"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "3.8.4"
+
+[package.dependencies]
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.6.0a1,<2.7.0"
+pyflakes = ">=2.2.0,<2.3.0"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
+
+[[package]]
 category = "main"
 description = "Git Object Database"
 name = "gitdb"
@@ -149,6 +166,14 @@ name = "markupsafe"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 version = "1.1.1"
+
+[[package]]
+category = "dev"
+description = "McCabe checker, plugin for flake8"
+name = "mccabe"
+optional = false
+python-versions = "*"
+version = "0.6.1"
 
 [[package]]
 category = "dev"
@@ -224,6 +249,22 @@ name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.8.2"
+
+[[package]]
+category = "dev"
+description = "Python style guide checker"
+name = "pycodestyle"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.6.0"
+
+[[package]]
+category = "dev"
+description = "passive checker of Python programs"
+name = "pyflakes"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.2.0"
 
 [[package]]
 category = "dev"
@@ -343,7 +384,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "1d9eb108a46231676f19db2a5c393196c9cfe59f687a021c95b1c30cf53cc562"
+content-hash = "395e695a2b7efa692b7dd3c7e1904f8025ce6a7d0c8ebb8d2eb82bd21bd8445a"
 python-versions = ">=3.5"
 
 [metadata.files]
@@ -376,6 +417,10 @@ dataclasses = [
 ]
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
+]
+flake8 = [
+    {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
+    {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
 ]
 gitdb = [
     {file = "gitdb-4.0.5-py3-none-any.whl", hash = "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac"},
@@ -428,6 +473,10 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
 more-itertools = [
     {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
     {file = "more_itertools-8.4.0-py3-none-any.whl", hash = "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"},
@@ -455,6 +504,14 @@ pluggy = [
 py = [
     {file = "py-1.8.2-py2.py3-none-any.whl", hash = "sha256:a673fa23d7000440cc885c17dbd34fafcb7d7a6e230b29f6766400de36a33c44"},
     {file = "py-1.8.2.tar.gz", hash = "sha256:f3b3a4c36512a4c4f024041ab51866f11761cc169670204b235f6b20523d4e6b"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
+    {file = "pycodestyle-2.6.0.tar.gz", hash = "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"},
+]
+pyflakes = [
+    {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
+    {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ Click = "^7.0"
 [tool.poetry.dev-dependencies]
 pytest = "^4.6"
 black = {version = "*", allow-prereleases = true, python = ">=3.6"}
+flake8 = "*"
 
 [tool.poetry.scripts]
 auto-changelog = 'auto_changelog.__main__:main'

--- a/tests/test_presenter.py
+++ b/tests/test_presenter.py
@@ -2,7 +2,7 @@ from datetime import date
 
 import pytest
 
-from auto_changelog.domain_model import Changelog, default_issue_pattern, default_tag_pattern
+from auto_changelog.domain_model import Changelog, default_issue_pattern
 from auto_changelog.presenter import MarkdownPresenter
 
 

--- a/tests/test_presenter.py
+++ b/tests/test_presenter.py
@@ -43,7 +43,8 @@ def test_markdown_presenter_changelog_with_features(changelog, markdown_presente
     changelog.add_note("", "feat", "description", scope="scope")
     description = "{}\n\n".format(changelog.description) if changelog.description else ""
     assert_markdown = (
-        "# {title}\n\n{description}## Unreleased (2020-01-01)\n\n#### New Features\n\n* description\n* (scope): description\n"
+        "# {title}\n\n{description}## Unreleased (2020-01-01)\n\n#### New Features\n\n"
+        "* description\n* (scope): description\n"
     ).format(title=changelog.title, description=description)
     markdown = markdown_presenter.present(changelog)
     assert assert_markdown == markdown

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -106,7 +106,8 @@ def test_tag_pattern(tags, tag_prefix, tag_pattern, expected_tags):
             ("feat", "", "description", "body", "Footer #1\nFooter: second"),
         ),
         (
-            "feat: description\n\nbody1\nbody2\n\nbodypara2\n\nFooter #1\nFooter: second but this a rather long footer\nspanning accross two lines\nFooter: third",
+            "feat: description\n\nbody1\nbody2\n\nbodypara2\n\nFooter #1\n"
+            "Footer: second but this a rather long footer\nspanning accross two lines\nFooter: third",
             (
                 "feat",
                 "",
@@ -126,7 +127,8 @@ def test_tag_pattern(tags, tag_prefix, tag_pattern, expected_tags):
         ),
         ("feat(scope): description\n\nbody\n\nFooter #1", ("feat", "scope", "description", "body", "Footer #1")),
         (
-            "fix: correct minor typos in code\n\nsee the issue for details\n\non typos fixed.\n\nReviewed-by: Z\nRefs #133",
+            "fix: correct minor typos in code\n\nsee the issue for details\n\non typos fixed.\n\n"
+            "Reviewed-by: Z\nRefs #133",
             (
                 "fix",
                 "",


### PR DESCRIPTION
Flake8 detects several code issues which are not detected by black, such as:

* undefined names
* unused variables
* unused imports
* invalid escape sequence

Initial flake8 run on master reported the following issues which have been resolved as part of this PR:
```
$ poetry run flake8 auto_changelog tests
auto_changelog/domain_model.py:9:54: W605 invalid escape sequence '\d'
auto_changelog/domain_model.py:9:58: W605 invalid escape sequence '\.'
auto_changelog/domain_model.py:9:77: W605 invalid escape sequence '\d'
auto_changelog/domain_model.py:9:81: W605 invalid escape sequence '\.'
auto_changelog/domain_model.py:9:100: W605 invalid escape sequence '\d'
auto_changelog/domain_model.py:9:121: E501 line too long (274 > 120 characters)
auto_changelog/domain_model.py:9:134: W605 invalid escape sequence '\d'
auto_changelog/domain_model.py:9:138: W605 invalid escape sequence '\d'
auto_changelog/domain_model.py:9:167: W605 invalid escape sequence '\.'
auto_changelog/domain_model.py:9:179: W605 invalid escape sequence '\d'
auto_changelog/domain_model.py:9:183: W605 invalid escape sequence '\d'
auto_changelog/domain_model.py:9:217: W605 invalid escape sequence '\+'
auto_changelog/domain_model.py:9:253: W605 invalid escape sequence '\.'
tests/test_repository.py:109:121: E501 line too long (163 > 120 characters)
tests/test_repository.py:129:121: E501 line too long (124 > 120 characters)
tests/test_presenter.py:5:1: F401 'auto_changelog.domain_model.default_tag_pattern' imported but unused
tests/test_presenter.py:46:121: E501 line too long (126 > 120 characters)
```

