### PR TITLE
fix: change option from --repo to --path-repo to remove conflit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,8 +44,8 @@ You can list the command line options by running `auto-changelog --help`:
     Usage: auto-changelog [OPTIONS]
     
     Options:
-      -r, --repo PATH            Path to the repository's root directory [Default:
-                                 .]
+      -p, --path-repo PATH       Path to the repository's root directory 
+                                 [Default: .]
     
       -t, --title TEXT           The changelog's title [Default: Changelog]
       -d, --description TEXT     Your project's description

--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -11,8 +11,8 @@ from auto_changelog.repository import GitRepository
 
 @click.command()
 @click.option(
-    "-r",
-    "--repo",
+    "-p",
+    "--path-repo",
     type=click.Path(exists=True),
     default=".",
     help="Path to the repository's root directory [Default: .]",
@@ -55,7 +55,7 @@ from auto_changelog.repository import GitRepository
     help="set logging level to DEBUG",
 )
 def main(
-    repo,
+    path_repo,
     title,
     description,
     output,
@@ -77,7 +77,7 @@ def main(
         logging.debug("Logging level has been set to DEBUG")
 
     # Convert the repository name to an absolute path
-    repo = os.path.abspath(repo)
+    repo = os.path.abspath(path_repo)
 
     repository = GitRepository(
         repo,

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -74,7 +74,7 @@ def test_help(runner):
     [["git remote add origin https://github.com/Michael-F-Bryan/auto-changelog.git"]],
 )
 def test_option_repo(test_repo, runner, open_changelog):
-    result = runner.invoke(main, ["--repo", test_repo])
+    result = runner.invoke(main, ["--path-repo", test_repo])
     assert result.exit_code == 0, result.stderr
     assert result.output == ""
     changelog = open_changelog().read()


### PR DESCRIPTION
Hello !

When I looked to the help of the command, I found really strange that the option `--repo` and `--remote` got the same short name which is `-r`.

I change the name of `--repo` to `--path-repo` to fix the conflit.

- [x] pytest :heavy_check_mark:
- [x] black :heavy_check_mark: